### PR TITLE
node v12.x is nolonger supported on lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Resources:
     Properties:
       CodeUri: atmProducer/
       Handler: handler.lambdaHandler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Policies:
         - Statement:
           - Effect: Allow
@@ -25,14 +25,14 @@ Resources:
     Properties:
       CodeUri: atmConsumer/
       Handler: handler.case1Handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
 
   atmConsumerCase2Fn:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: atmConsumer/
       Handler: handler.case2Handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Events:
         Trigger:
           Type: CloudWatchEvent 
@@ -51,7 +51,7 @@ Resources:
     Properties:
       CodeUri: atmConsumer/
       Handler: handler.case3Handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Events:
         Trigger:
           Type: CloudWatchEvent 


### PR DESCRIPTION
*Issue #, if available:* node version 12.x is not supported on AWS lambda platform based on the aws lambda docs.

*Description of changes:* Upgraded it to 16.x. I avoided to use 18.x because I would get an exception that aws-sdk module is not found.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
